### PR TITLE
Issue/17

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: 3.1.x
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: 5.0.x
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v1.7.2
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,13 +53,13 @@ jobs:
 #        files: coverage.cobertura.xml
 #        verbose: true
 
-    - name: Run Stryker.NET
-      run: cd ./Shimterface.Tests/; dotnet stryker --project Shimterface.Standard.Tests.csproj --reporters "['cleartext','html','dashboard']" --dashboard-api-key ${{ secrets.STRYKER_DASHBOARD }} --dashboard-project github.com/IFYates/Shimterface --dashboard-version $GITHUB_REF
-    - name: Upload mutation report
-      uses: actions/upload-artifact@v2.2.2
-      with:
-        name: mutation-report.html
-        path: ./**/mutation-report.html
+#    - name: Run Stryker.NET
+#      run: cd ./Shimterface.Tests/; dotnet stryker --project Shimterface.Standard.Tests.csproj --reporters "['cleartext','html','dashboard']" --dashboard-api-key ${{ secrets.STRYKER_DASHBOARD }} --dashboard-project github.com/IFYates/Shimterface --dashboard-version $GITHUB_REF
+#    - name: Upload mutation report
+#      uses: actions/upload-artifact@v2.2.2
+#      with:
+#        name: mutation-report.html
+#        path: ./**/mutation-report.html
 
     - name: Publish package
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,7 +54,7 @@ jobs:
 #        verbose: true
 
     - name: Run Stryker.NET
-      run: cd ./Shimterface.Tests/; dotnet stryker --reporters "['cleartext','html','dashboard']" --dashboard-api-key ${{ secrets.STRYKER_DASHBOARD }} --dashboard-project github.com/IFYates/Shimterface --dashboard-version $GITHUB_REF
+      run: cd ./Shimterface.Tests/Shimterface.Standard.Tests.csproj; dotnet stryker --reporters "['cleartext','html','dashboard']" --dashboard-api-key ${{ secrets.STRYKER_DASHBOARD }} --dashboard-project github.com/IFYates/Shimterface --dashboard-version $GITHUB_REF
     - name: Upload mutation report
       uses: actions/upload-artifact@v2.2.2
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,7 +54,7 @@ jobs:
 #        verbose: true
 
     - name: Run Stryker.NET
-      run: cd ./Shimterface.Tests/Shimterface.Standard.Tests.csproj; dotnet stryker --reporters "['cleartext','html','dashboard']" --dashboard-api-key ${{ secrets.STRYKER_DASHBOARD }} --dashboard-project github.com/IFYates/Shimterface --dashboard-version $GITHUB_REF
+      run: cd ./Shimterface.Tests/; dotnet stryker --project Shimterface.Standard.Tests.csproj --reporters "['cleartext','html','dashboard']" --dashboard-api-key ${{ secrets.STRYKER_DASHBOARD }} --dashboard-project github.com/IFYates/Shimterface --dashboard-version $GITHUB_REF
     - name: Upload mutation report
       uses: actions/upload-artifact@v2.2.2
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup .NET 5
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/Shimterface.Standard.sln
+++ b/Shimterface.Standard.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29326.143
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D260D65D-0F00-4D2C-9E72-38EC9D2E3F41}"
 	ProjectSection(SolutionItems) = preProject

--- a/Shimterface.Tests/GenericConstructorTests.cs
+++ b/Shimterface.Tests/GenericConstructorTests.cs
@@ -17,6 +17,8 @@ namespace Shimterface.Tests
         public interface IFactoryInterface
         {
             [ConstructorShim(typeof(TestClass<>))]
+            IInstanceInterface<T> Create<T>();
+            [ConstructorShim(typeof(TestClass<>))]
             IInstanceInterface<T> Create<T>(T value);
             [ConstructorShim(typeof(TestClass<>))]
             IInstanceInterface<T> Create<T>(IEnumerable<T> value);
@@ -31,6 +33,10 @@ namespace Shimterface.Tests
             public string Text { get; set; }
             public int Count { get; set; }
 
+            public TestClass()
+            {
+                Count = 0;
+            }
             public TestClass(T value)
             {
                 Value = value;
@@ -51,6 +57,17 @@ namespace Shimterface.Tests
         public interface ITest
         {
             object Exec();
+        }
+
+        [TestMethod]
+        public void Can_shim_to_constructor_without_args()
+        {
+            var shim = ShimBuilder.Create<IFactoryInterface>();
+
+            var inst = shim.Create<string>();
+
+            Assert.AreEqual(0, inst.Count);
+            Assert.IsInstanceOfType(((IShim)inst).Unshim(), typeof(TestClass<string>));
         }
 
         [TestMethod]

--- a/Shimterface.Tests/Internal/ILBuilderTests.cs
+++ b/Shimterface.Tests/Internal/ILBuilderTests.cs
@@ -12,28 +12,6 @@ namespace Shimterface.Internal.Tests
     public class ILBuilderTests
     {
         [TestMethod]
-        [DataRow((byte)0, 1)]
-        [DataRow((byte)1, 1)]
-        [DataRow((byte)2, 1)]
-        [DataRow((byte)3, 1)]
-        [DataRow((byte)4, 2)]
-        [DataRow((byte)5, 2)]
-        public void Ldarg__Provides_efficient_bytecode(byte input, int expOffset)
-        {
-            // Arrange
-            var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Shimterface.Tests.dynamic"), AssemblyBuilderAccess.Run);
-            var mod = asm.DefineDynamicModule("Shimterface.Tests.dynamic");
-            var tb = mod.DefineType($"TestClass", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AutoClass | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.AutoLayout, null, null);
-
-            // Act
-            var impl = tb.DefinePublicMethod("TestMethod", typeof(bool), new List<Type> { typeof(string), typeof(int) });
-            ILBuilder.Ldarg(impl, input);
-
-            // Assert
-            Assert.AreEqual(expOffset, impl.ILOffset);
-        }
-
-        [TestMethod]
         public void DefinePublicMethod__With_paramTypes__Creates_method()
         {
             // Arrange

--- a/Shimterface.Tests/Internal/ILGeneratorExtensionsTests.cs
+++ b/Shimterface.Tests/Internal/ILGeneratorExtensionsTests.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Shimterface.Internal.Tests
+{
+    [TestClass]
+    public class ILGeneratorExtensionsTests
+    {
+        private static ILGenerator getGenerator()
+        {
+            var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Shimterface.Tests.dynamic"), AssemblyBuilderAccess.Run);
+            var mod = asm.DefineDynamicModule("Shimterface.Tests.dynamic");
+            var tb = mod.DefineType($"TestClass", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AutoClass | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.AutoLayout, null, null);
+            return tb.DefinePublicMethod("TestMethod", typeof(bool), new List<Type> { typeof(string), typeof(int) });
+        }
+
+        [TestMethod]
+        [DataRow((byte)0, 1)]
+        [DataRow((byte)1, 1)]
+        [DataRow((byte)2, 1)]
+        [DataRow((byte)3, 1)]
+        [DataRow((byte)4, 2)]
+        [DataRow((byte)5, 2)]
+        public void Ldarg__Provides_efficient_bytecode(byte input, int expOffset)
+        {
+            // Arrange
+            var impl = getGenerator();
+
+            // Act
+            ILGeneratorExtensions.Ldarg(impl, input);
+
+            // Assert
+            Assert.AreEqual(expOffset, impl.ILOffset);
+        }
+
+        [TestMethod]
+        [DataRow((byte)0, 1)]
+        [DataRow((byte)1, 1)]
+        [DataRow((byte)2, 1)]
+        [DataRow((byte)3, 1)]
+        [DataRow((byte)4, 1)]
+        [DataRow((byte)5, 1)]
+        [DataRow((byte)6, 1)]
+        [DataRow((byte)7, 1)]
+        [DataRow((byte)8, 1)]
+        [DataRow((byte)9, 2)]
+        [DataRow((byte)10, 2)]
+        public void Ldc_I4__Provides_efficient_bytecode(byte input, int expOffset)
+        {
+            // Arrange
+            var impl = getGenerator();
+
+            // Act
+            ILGeneratorExtensions.Ldc_I4(impl, input);
+
+            // Assert
+            Assert.AreEqual(expOffset, impl.ILOffset);
+        }
+
+        [TestMethod]
+        [DataRow((byte)0, 1)]
+        [DataRow((byte)1, 1)]
+        [DataRow((byte)2, 1)]
+        [DataRow((byte)3, 1)]
+        [DataRow((byte)4, 6)]
+        [DataRow((byte)5, 6)]
+        public void Ldloc__Provides_efficient_bytecode(byte input, int expOffset)
+        {
+            // Arrange
+            var impl = getGenerator();
+
+            // Act
+            ILGeneratorExtensions.Ldloc(impl, input);
+
+            // Assert
+            Assert.AreEqual(expOffset, impl.ILOffset);
+        }
+
+        [TestMethod]
+        [DataRow((byte)0, 1)]
+        [DataRow((byte)1, 1)]
+        [DataRow((byte)2, 1)]
+        [DataRow((byte)3, 1)]
+        [DataRow((byte)4, 6)]
+        [DataRow((byte)5, 6)]
+        public void Stloc__Provides_efficient_bytecode(byte input, int expOffset)
+        {
+            // Arrange
+            var impl = getGenerator();
+
+            // Act
+            ILGeneratorExtensions.Stloc(impl, input);
+
+            // Assert
+            Assert.AreEqual(expOffset, impl.ILOffset);
+        }
+    }
+}

--- a/Shimterface.Tests/Internal/ILGeneratorExtensionsTests.cs
+++ b/Shimterface.Tests/Internal/ILGeneratorExtensionsTests.cs
@@ -46,8 +46,13 @@ namespace Shimterface.Internal.Tests
         [DataRow((byte)6, 1)]
         [DataRow((byte)7, 1)]
         [DataRow((byte)8, 1)]
+#if NETCOREAPP3_1
+        [DataRow((byte)9, 5)]
+        [DataRow((byte)10, 5)]
+#else
         [DataRow((byte)9, 2)]
         [DataRow((byte)10, 2)]
+#endif
         public void Ldc_I4__Provides_efficient_bytecode(byte input, int expOffset)
         {
             // Arrange

--- a/Shimterface.Tests/Shimterface - Backup.Standard.Tests.csproj
+++ b/Shimterface.Tests/Shimterface - Backup.Standard.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>Shimterface.Tests</RootNamespace>
     </PropertyGroup>

--- a/Shimterface.Tests/Shimterface.Standard.Tests.csproj
+++ b/Shimterface.Tests/Shimterface.Standard.Tests.csproj
@@ -5,7 +5,7 @@
         <RootNamespace>Shimterface.Tests</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
       <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
       <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
       <PackageReference Include="Moq" Version="4.16.1" />

--- a/Shimterface/Internal/ILBuilder.cs
+++ b/Shimterface/Internal/ILBuilder.cs
@@ -8,28 +8,6 @@ namespace Shimterface.Internal
 {
     internal static class ILBuilder
     {
-        public static void Ldarg(this ILGenerator impl, byte num)
-        {
-            switch (num)
-            {
-                case 0:
-                    impl.Emit(OpCodes.Ldarg_0);
-                    break;
-                case 1:
-                    impl.Emit(OpCodes.Ldarg_1);
-                    break;
-                case 2:
-                    impl.Emit(OpCodes.Ldarg_2);
-                    break;
-                case 3:
-                    impl.Emit(OpCodes.Ldarg_3);
-                    break;
-                default:
-                    impl.Emit(OpCodes.Ldarg_S, num);
-                    break;
-            }
-        }
-
         private static bool resolveIfInstance(bool isStatic, ILGenerator impl, FieldInfo? instField)
         {
             if (isStatic || instField == null)
@@ -175,7 +153,7 @@ namespace Shimterface.Internal
 
         public static void WrapConstructor(this TypeBuilder tb, ShimBinding binding, ConstructorInfo constrInfo)
         {
-            var factory = tb.DefinePublicMethod(binding.InterfaceMethod, out var args);
+            var factory = tb.DefinePublicMethod(binding.InterfaceMethod, out var argTypes);
             var impl = factory.GetILGenerator();
             var genericParams = factory.GetGenericArguments();
 
@@ -184,22 +162,27 @@ namespace Shimterface.Internal
                 // Build args array
                 var pars = binding.InterfaceMethod.GetParameters();
                 var argsArr = impl.DeclareLocal(typeof(object[]));
-                impl.Emit(OpCodes.Ldc_I4, args.Length);
+                impl.Ldc_I4(argTypes.Length);
                 impl.Emit(OpCodes.Newarr, typeof(object));
-                for (var i = 0; i < args.Length; ++i)
+                for (var i = 0; i < argTypes.Length; ++i)
                 {
                     impl.Emit(OpCodes.Dup);
-                    impl.Emit(OpCodes.Ldc_I4, i);
+                    impl.Ldc_I4(i);
                     impl.Ldarg((byte)(i + 1));
-                    impl.Emit(OpCodes.Box, args[i]);
+                    impl.Emit(OpCodes.Box, argTypes[i]);
                     impl.Emit(OpCodes.Stelem_Ref);
                 }
-                impl.Emit(OpCodes.Stloc, argsArr.LocalIndex);
+                impl.Stloc(argsArr.LocalIndex);
 
                 // Build target type
-                impl.Emit(OpCodes.Ldtoken, constrInfo.DeclaringType.RebuildGenericType(genericParams));
-                impl.Emit(OpCodes.Ldloc, argsArr.LocalIndex);
+                var resultType = constrInfo.DeclaringType.RebuildGenericType(genericParams);
+                impl.Emit(OpCodes.Ldtoken, resultType);
+                //impl.Emit(OpCodes.Call, typeof(Type).
+                impl.Ldloc(argsArr.LocalIndex);
                 impl.Emit(OpCodes.Call, typeof(Activator).GetMethod(nameof(Activator.CreateInstance), new[] { typeof(Type), typeof(object[]) }));
+                //impl.Emit(OpCodes.Castclass, resultType);
+                //impl.Stloc(1);
+                //impl.Ldloc(1);
             }
             else
             {

--- a/Shimterface/Internal/ILBuilder.cs
+++ b/Shimterface/Internal/ILBuilder.cs
@@ -177,12 +177,9 @@ namespace Shimterface.Internal
                 // Build target type
                 var resultType = constrInfo.DeclaringType.RebuildGenericType(genericParams);
                 impl.Emit(OpCodes.Ldtoken, resultType);
-                //impl.Emit(OpCodes.Call, typeof(Type).
+                impl.Emit(OpCodes.Call, typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle), new[] { typeof(RuntimeTypeHandle) }));
                 impl.Ldloc(argsArr.LocalIndex);
                 impl.Emit(OpCodes.Call, typeof(Activator).GetMethod(nameof(Activator.CreateInstance), new[] { typeof(Type), typeof(object[]) }));
-                //impl.Emit(OpCodes.Castclass, resultType);
-                //impl.Stloc(1);
-                //impl.Ldloc(1);
             }
             else
             {

--- a/Shimterface/Internal/ILGeneratorExtensions.cs
+++ b/Shimterface/Internal/ILGeneratorExtensions.cs
@@ -1,0 +1,89 @@
+﻿using System.Reflection.Emit;
+
+namespace Shimterface.Internal
+{
+    internal static class ILGeneratorExtensions
+    {
+        public static void Ldarg(this ILGenerator impl, byte num)
+        {
+            var op = num switch
+            {
+                0 => OpCodes.Ldarg_0,
+                1 => OpCodes.Ldarg_1,
+                2 => OpCodes.Ldarg_2,
+                3 => OpCodes.Ldarg_3,
+                _ => default
+            };
+            if (op.Value > 0)
+            {
+                impl.Emit(op);
+            }
+            else
+            {
+                impl.Emit(OpCodes.Ldarg_S, num);
+            }
+        }
+        public static void Ldc_I4(this ILGenerator impl, int num)
+        {
+            var op = num switch
+            {
+                0 => OpCodes.Ldc_I4_0,
+                1 => OpCodes.Ldc_I4_1,
+                2 => OpCodes.Ldc_I4_2,
+                3 => OpCodes.Ldc_I4_3,
+                4 => OpCodes.Ldc_I4_4,
+                5 => OpCodes.Ldc_I4_5,
+                6 => OpCodes.Ldc_I4_6,
+                7 => OpCodes.Ldc_I4_7,
+                8 => OpCodes.Ldc_I4_8,
+                _ => default
+            };
+            if (op.Value > 0)
+            {
+                impl.Emit(op);
+            }
+            else
+            {
+                impl.Emit(OpCodes.Ldc_I4, num);
+            }
+        }
+        public static void Ldloc(this ILGenerator impl, int num)
+        {
+            var op = num switch
+            {
+                0 => OpCodes.Ldloc_0,
+                1 => OpCodes.Ldloc_1,
+                2 => OpCodes.Ldloc_2,
+                3 => OpCodes.Ldloc_3,
+                _ => default
+            };
+            if (op.Value > 0)
+            {
+                impl.Emit(op);
+            }
+            else
+            {
+                impl.Emit(OpCodes.Ldloc, num); // TODO: Might be able to use Ldloc_S
+            }
+        }
+        public static void Stloc(this ILGenerator impl, int num)
+        {
+            var op = num switch
+            {
+                0 => OpCodes.Stloc_0,
+                1 => OpCodes.Stloc_1,
+                2 => OpCodes.Stloc_2,
+                3 => OpCodes.Stloc_3,
+                _ => default
+            };
+            if (op.Value > 0)
+            {
+                impl.Emit(op);
+            }
+            else
+            {
+                impl.Emit(OpCodes.Stloc, num); // TODO: Might be able to use Stloc_S
+            }
+        }
+    }
+}

--- a/Shimterface/Shimterface.Standard.csproj
+++ b/Shimterface/Shimterface.Standard.csproj
@@ -4,13 +4,14 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>IFYates</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.6.6</Version>
-        <AssemblyVersion>1.6.6</AssemblyVersion>
-        <FileVersion>1.6.6</FileVersion>
+        <Version>1.6.7</Version>
+        <AssemblyVersion>1.6.7</AssemblyVersion>
+        <FileVersion>1.6.7</FileVersion>
         <PackageProjectUrl>https://github.com/IFYates/Shimterface</PackageProjectUrl>
         <RepositoryUrl>https://github.com/IFYates/Shimterface</RepositoryUrl>
         <RepositoryType>GitHub</RepositoryType>
-        <PackageReleaseNotes>[v1.6.6] Fixed issue #16 - invalid shim for multiple args to generic type constructor
+        <PackageReleaseNotes>[v1.6.7] Fixed issue #17 - .NET 6 support for constructors on generic types
+[v1.6.6] Fixed issue #16 - invalid shim for multiple args to generic type constructor
 [v1.6.5] Generic method can be used to construct a generic type (Issue #14)
 [v1.6.4] Can specify true implementation type in attribute, to work around explicit implementation hiding
 [v1.6.3] Fixed issue #12 - shim of hidden property


### PR DESCRIPTION
Fixed .NET 6 failing to use shim on generic type constructor
Minor efficiency improvements to generated IL
Tests now run for .NET Core 3.1, .NET 5, .NET 6